### PR TITLE
Handle hyphens in time input

### DIFF
--- a/src/main/java/seedu/internsprint/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/internsprint/logic/parser/DateTimeParser.java
@@ -111,6 +111,12 @@ public class DateTimeParser {
         return group.getDates().get(0);
     }
 
+    /**
+     * Normalizes the time input string by replacing hyphens with colons and ensuring proper formatting.
+     *
+     * @param input Time input string.
+     * @return Normalized time input string.
+     */
     private static String normalizeTimeInput(String input) {
         String normalized = input.toLowerCase();
         normalized = normalized.replaceAll("(\\d{1,2})-(am|pm)", "$1 $2");

--- a/src/main/java/seedu/internsprint/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/internsprint/logic/parser/DateTimeParser.java
@@ -49,6 +49,8 @@ public class DateTimeParser {
      * @return The LocalTime object.
      */
     public static LocalTime parseTimeInput(String input) {
+        input = normalizeTimeInput(input);
+        System.out.println("Normalized input: " + input);
         Date date = extractDate(input);
         return LocalTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
     }
@@ -108,4 +110,13 @@ public class DateTimeParser {
         }
         return group.getDates().get(0);
     }
+
+    private static String normalizeTimeInput(String input) {
+        String normalized = input.toLowerCase();
+        normalized = normalized.replaceAll("(\\d{1,2})-(am|pm)", "$1 $2");
+        normalized = normalized.replaceAll("(\\d{1,2})-(\\d{2})(?!\\s*(am|pm))", "$1:$2");
+        normalized = normalized.replaceAll("(\\d{1,2})-(\\d{2})(?=(am|pm))", "$1:$2");
+        return normalized;
+    }
+
 }

--- a/src/test/java/seedu/internsprint/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/internsprint/logic/parser/DateTimeParserTest.java
@@ -32,6 +32,13 @@ class DateTimeParserTest {
     }
 
     @Test
+    void parseTimeInput_provideHypenatedTime_returnsCorrectObject() {
+        assertEquals("11:00", DateTimeParser.parseTimeInput("11-00").toString());
+        assertEquals("17:00", DateTimeParser.parseTimeInput("5-00pm").toString());
+        assertEquals("17:00", DateTimeParser.parseTimeInput("5-PM").toString());
+    }
+
+    @Test
     void parseDateTimeInput_provideNaturalLanguageDateTime_returnsCorrectObject() {
         LocalDate today = LocalDate.now();
         assertEquals(today.plusDays(1).atTime(17, 0).toString(),


### PR DESCRIPTION
Fixes #206 

Regular expression matching is used to find the hyphens in time input and convert them to colons or spaces.