### PR TITLE
Handle Natty error messages printed to the console

### DIFF
--- a/src/main/java/seedu/internsprint/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/internsprint/logic/parser/DateTimeParser.java
@@ -1,5 +1,7 @@
 package seedu.internsprint.logic.parser;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -50,7 +52,6 @@ public class DateTimeParser {
      */
     public static LocalTime parseTimeInput(String input) {
         input = normalizeTimeInput(input);
-        System.out.println("Normalized input: " + input);
         Date date = extractDate(input);
         return LocalTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
     }
@@ -95,6 +96,9 @@ public class DateTimeParser {
      * @return The extracted date.
      */
     private static Date extractDate(String input) {
+        ByteArrayOutputStream NattyErrorStream = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(NattyErrorStream));
+
         Parser parser = new Parser();
         List<DateGroup> groups = parser.parse(input);
 
@@ -106,7 +110,7 @@ public class DateTimeParser {
         String matchedText = group.getText().toLowerCase();
 
         if (!input.toLowerCase().equals(matchedText)) {
-            throw new IllegalArgumentException(String.format(PARTIAL_DATE_FORMAT, matchedText));
+            throw new IllegalArgumentException(String.format(PARTIAL_DATE_FORMAT, input, matchedText));
         }
         return group.getDates().get(0);
     }

--- a/src/main/java/seedu/internsprint/util/InternSprintExceptionMessages.java
+++ b/src/main/java/seedu/internsprint/util/InternSprintExceptionMessages.java
@@ -8,8 +8,8 @@ public class InternSprintExceptionMessages {
     public static final String REPEATED_FLAG = "Repeated flag found: %s";
 
     public static final String INVALID_DATE_FORMAT = "Invalid date format or no date found";
-    public static final String PARTIAL_DATE_FORMAT = "Some input words is not recognized as a date. \n"
-        + "    Date interpreted is: %s. Please give a better format.";
+    public static final String PARTIAL_DATE_FORMAT = "Some input words is not recognized as a date/time. \n"
+        + "    Date/Time interpreted from %s is: %s. Please give a better format.";
     public static final String END_TIME_BEFORE_START_TIME = "Interview start time cannot be after end time.";
 
     public static final String UNABLE_TO_CREATE_DIRECTORY = "Unable to create directory: %s";


### PR DESCRIPTION
Natty prints error messages directly to system.err. So let's redirect these messages to a custom print stream to avoid displaying unnecessary messages to the user.

![image](https://github.com/user-attachments/assets/b3b01354-2787-49b9-b284-299936f0d4f6)

The error messages are not displayed now.

Fixes #188